### PR TITLE
fix bug CycleTLS/issues/323

### DIFF
--- a/client.go
+++ b/client.go
@@ -800,7 +800,7 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(*Request) {
 		// See https://github.com/Danny-Dasilva/CycleTLS/issues/323
 		if shouldUpdateHostInHeader(&ireqhdr, req) {
 			if ireqhdr.has("Host") {
-				if hhost, ok := ireqhdr["Host"]; ok {
+				if hhost, ok := ireqhdr["Host"]; ok && len(hhost) > 0 {
 					hhost[0] = req.URL.Host
 				} else {
 					ireqhdr["Host"] = []string{req.URL.Host}

--- a/client.go
+++ b/client.go
@@ -789,20 +789,32 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(*Request) {
 			}
 		}
 
+		// Because we copy a headers are from the very initial request.
+		// When there is a redirect, we continue to supply the wrong Host,
+		// some sites link to the Host in the headers, which is why we will
+		// not be able to make requests with a redirect to such sites.
+		//
+		// If it turns out that there was a redirect,
+		// then I check whether I should change the Host in the headers
+		//
+		// See https://github.com/Danny-Dasilva/CycleTLS/issues/323
+		if shouldUpdateHostInHeader(&ireqhdr, req) {
+			if ireqhdr.has("Host") {
+				if hhost, ok := ireqhdr["Host"]; ok {
+					hhost[0] = req.URL.Host
+				} else {
+					ireqhdr["Host"] = []string{req.URL.Host}
+				}
+
+			} else {
+				ireqhdr.Set("Host", req.URL.Host)
+			}
+		}
+
 		// Copy the initial request's Header Values
 		// (at least the safe ones).
 		for k, vv := range ireqhdr {
 			if shouldCopyHeaderOnRedirect(k, preq.URL, req.URL) {
-				if k == "Host" && preq.URL.Host != req.URL.Host {
-					if len(vv) == 0 {
-						vv = append(vv, req.URL.Host)
-					} else {
-						vv[0] = req.URL.Host
-					}
-
-					req.Header[k] = vv
-					continue
-				}
 				req.Header[k] = vv
 			}
 		}
@@ -1016,4 +1028,19 @@ func stripPassword(u *url.URL) string {
 		return strings.Replace(u.String(), u.User.String()+"@", u.User.Username()+":***@", 1)
 	}
 	return u.String()
+}
+
+func shouldUpdateHostInHeader(firstHeader *Header, curr *Request) bool {
+	if curr == nil || firstHeader == nil || curr.Response == nil {
+		return false
+	}
+	headers := *firstHeader
+
+	switch curr.Response.StatusCode {
+	case 301, 302, 303, 307, 308:
+		host, ok := headers["Host"]
+		return !ok || len(host) == 0 || host[0] != curr.URL.Host
+	}
+	// All other ways:
+	return false
 }

--- a/client.go
+++ b/client.go
@@ -793,6 +793,16 @@ func (c *Client) makeHeadersCopier(ireq *Request) func(*Request) {
 		// (at least the safe ones).
 		for k, vv := range ireqhdr {
 			if shouldCopyHeaderOnRedirect(k, preq.URL, req.URL) {
+				if k == "Host" && preq.URL.Host != req.URL.Host {
+					if len(vv) == 0 {
+						vv = append(vv, req.URL.Host)
+					} else {
+						vv[0] = req.URL.Host
+					}
+
+					req.Header[k] = vv
+					continue
+				}
 				req.Header[k] = vv
 			}
 		}


### PR DESCRIPTION
based on the motives [CycleTLS/issues#323](https://github.com/Danny-Dasilva/CycleTLS/issues/323)

was: 
![Снимок экрана 2024-02-09 в 14 42 33](https://github.com/Danny-Dasilva/fhttp/assets/22912194/5bbdf46c-52c5-44d3-9e68-069f53e78c4a)


now:
![Снимок экрана 2024-02-09 в 14 26 27](https://github.com/Danny-Dasilva/fhttp/assets/22912194/ccd36b00-0626-4b7c-ad38-59c3036382ab)

I added in go.mode "replace github.com/Danny-Dasilva/fhttp => ./github/http" locally and ran tests, nothing was broken.
test passed:

> 
> CycleTLS_cycletls_tests_integration.test -test.v -test.paniconexit0
> === RUN   TestInsecureSkipVerify_true
> --- PASS: TestInsecureSkipVerify_true (0.89s)
> === RUN   TestInsecureSkipVerify_false
> --- PASS: TestInsecureSkipVerify_false (0.83s)
> === RUN   TestUrlEncodedFormDataUpload
> --- PASS: TestUrlEncodedFormDataUpload (0.42s)
> === RUN   TestCookieHandling
> --- PASS: TestCookieHandling (4.41s)
> === RUN   TestCookies
> --- PASS: TestCookies (0.83s)
> === RUN   TestDeflateDecoding
> --- PASS: TestDeflateDecoding (0.84s)
> === RUN   TestBrotliDecoding
> --- PASS: TestBrotliDecoding (0.93s)
> === RUN   TestGZIPDecoding
> --- PASS: TestGZIPDecoding (0.82s)
> === RUN   TestRedirectEnabled
> --- PASS: TestRedirectEnabled (2.69s)
> === RUN   TestRedirectDisabled
> --- PASS: TestRedirectDisabled (0.83s)
> === RUN   TestRedirectEnabled_NewURL
> --- PASS: TestRedirectEnabled_NewURL (8.56s)
> === RUN   TestRedirectDisabled_NewURL
> --- PASS: TestRedirectDisabled_NewURL (0.85s)
> === RUN   TestFileWriting
> --- PASS: TestFileWriting (2.43s)
> === RUN   TestLatestVersions
> --- PASS: TestLatestVersions (1.89s)
> === RUN   TestHTTP2
> --- PASS: TestHTTP2 (41.68s)
> === RUN   TestMultipartFormDataMixed
> --- PASS: TestMultipartFormDataMixed (0.39s)
> === RUN   TestMultipartFormDataUpload
> --- PASS: TestMultipartFormDataUpload (0.42s)
> === RUN   TestMultipartFormDataText
> --- PASS: TestMultipartFormDataText (0.40s)
> === RUN   TestDelayResponseOrder
> 2024/02/09 14:45:10 Worker Pool Started
> --- PASS: TestDelayResponseOrder (3.54s)
> PASS
> 
> Process finished with the exit code 0
> 
